### PR TITLE
Electing which msg's will be sent to MQTT, with or without rsp ; to resolve delay / consistency issue

### DIFF
--- a/Lora/Lora.c
+++ b/Lora/Lora.c
@@ -89,7 +89,7 @@ void send_command(enum cmd_enum cmd) {
                         strlen(commands[cmd]));
 }
 
-bool get_cmd_rps(enum cmd_enum cmd, bool loading_bar) {
+bool get_cmd_rsp(enum cmd_enum cmd, bool loading_bar) {
     char response[STRLEN_LORA];
     while (uart_is_readable_within_us(UART_ID, UART_WAIT_US)) {
         if (loading_bar) printf("#");
@@ -110,7 +110,7 @@ bool connect_network() {
            "/LOADING\\\n");
     for (enum cmd_enum cmd = MODE; cmd <= JOIN; cmd++) {
         send_command(cmd);
-        if (!get_cmd_rps(cmd, true)) {
+        if (!get_cmd_rsp(cmd, true)) {
             fprintf(stderr, "\nLoRa command failed: %s""Connection failed.\n\n", commands[cmd]);
             return false;
         }
@@ -125,5 +125,5 @@ void send_msg_to_Lora(const char *content, bool wait_for_rsp) {
     uart_write_blocking(UART_ID,
                         (uint8_t *) data,
                         strlen(data));
-    if (wait_for_rsp) get_cmd_rps(MSG, false);
+    if (wait_for_rsp) get_cmd_rsp(MSG, false);
 }

--- a/operation/operation.c
+++ b/operation/operation.c
@@ -103,15 +103,13 @@ void logf_msg(enum logs logEnum, oper_st * state, int n_args, ...) {
             write_to_eeprom(PILLS_DETECTION_ADDR,
                             &state->pills_detected, 1);
             break;
-        default:
-            ;
+        default: ;
     }
 
     // Cases where LoRa msg's will be sent, and how
     switch (logEnum) {
         /// Msg sent and response waited for in:
         case LORA_SUCCEED:
-        case WAITING_FOR_SW:
         case CALIB_COMPLETED:
         case RECALIB_AFTER_REBOOT:
         case DISPENSE_CONTINUED:

--- a/operation/operation.c
+++ b/operation/operation.c
@@ -146,7 +146,11 @@ oper_st init_operation() {
     init_Lora();
     start_lora();
 
-    state.lora_connected = connect_network();
+    // retry connection once if first try fails
+    if (!(state.lora_connected = connect_network())) {
+        printf("Retrying...\n");
+        state.lora_connected = connect_network();
+    }
     logf_msg(state.lora_connected ? LORA_SUCCEED : LORA_FAILED, &state, 0);
 
     state.led = init_pwm(LED_3);
@@ -180,7 +184,7 @@ void press_sw_to_read_log(oper_st * state) {
     if (switch_pressed_debounced(&state->sw_log)) {
         logf_msg(SW_PRESSED, state,
                  1, state->sw_log.board_index);
-        read_log_entry(state->current_comp_idx);
+        read_log_entry(state->eeprom_log_idx);
     }
 }
 

--- a/operation/operation.c
+++ b/operation/operation.c
@@ -112,7 +112,6 @@ void logf_msg(enum logs logEnum, oper_st * state, int n_args, ...) {
         /// Msg sent and response waited for in:
         case LORA_SUCCEED:
         case WAITING_FOR_SW:
-        case CALIB_START:
         case CALIB_COMPLETED:
         case RECALIB_AFTER_REBOOT:
         case DISPENSE_CONTINUED:

--- a/operation/operation.c
+++ b/operation/operation.c
@@ -289,7 +289,7 @@ void dispense(oper_st * state) {
             press_sw_to_read_log(state);
             sleep_ms(5);
         }
-        
+
         logf_msg(ROTATION_CONTINUED, state, 1, state->current_comp_idx + 1);
         interrupt_flags[PIEZO_FALL] = false;
         rotate_8th(1);

--- a/operation/operation.c
+++ b/operation/operation.c
@@ -107,14 +107,23 @@ void logf_msg(enum logs logEnum, oper_st * state, int n_args, ...) {
             ;
     }
 
-    // LoRa messages to be sent to mqtt
+    // Cases where LoRa msg's will be sent, and how
     switch (logEnum) {
-        case BOOT:
-        case LORA_FAILED:
-            break;
-        default:
+        /// Msg sent and response waited for in:
+        case LORA_SUCCEED:
+        case WAITING_FOR_SW:
+        case CALIB_START:
+        case CALIB_COMPLETED:
+        case RECALIB_AFTER_REBOOT:
+        case DISPENSE_CONTINUED:
+        case DISPENSE_COMPLETED:
+        case PILL_FOUND:
+        case NO_PILL_FOUND:
             if (state->lora_connected)
-                send_msg_to_Lora(msg, false);
+                send_msg_to_Lora(msg, true);
+            break;
+        /// No msg sent in the rest:
+        default: ;
     }
 }
 


### PR DESCRIPTION
This setup waits for responses and suffers the delay, but thus also
picks which ones are important enough to be sent and which ones are not.

To recap:
If a msg is sent and its rsp is not waited for,
a msg sent (within a short time interval) after the previous one is lost the void
as the LoRa module / the server is still processing the previous msg ;
thus (atm) I worry that it's too big of a risk to send msg's ever without waiting for rsp...
The program as a whole doesn't mind ; it just moves on regardless of what LoRa is or isn't doing.

But this ought to be tested before deciding ;
this leans heavily on the feel of the UX delay,
in addition to the levels of criticality of the msg's.